### PR TITLE
MM-340: Externalize current eslint rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+sudo: false
+language: node_js
+node_js: "4.4"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# eslint-config-mm
+
+Eslint rules for Matchminds projects
+
+## Usage
+
+1. Install this module as a devDependency:
+    ```shell
+    npm install --save-dev eslint-config-mm
+    ```
+
+2. Add a `.eslintrc` file to your project root similar to this:
+    ```json
+    {
+      "root": true,
+      "extends": ["eslint-config-enrise-mm"]
+    }
+    ```
+
+3. Optionally add one-off rule deviations to your local `.eslintrc` file.
+
+## Flavours
+
+Linting rules are available in ES5 and ES6 flavours. ES6 is the default.
+
+Using a different flavour can be done by extending from a specific file in this module. For example:
+
+```json
+{
+  "root": true,
+  "extends": ["eslint-config-enrise-mm/es5"]
+}
+```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Eslint rules for Matchminds projects
     ```json
     {
       "root": true,
-      "extends": ["eslint-config-enrise-mm"]
+      "extends": ["eslint-config-mm"]
     }
     ```
 
@@ -28,6 +28,6 @@ Using a different flavour can be done by extending from a specific file in this 
 ```json
 {
   "root": true,
-  "extends": ["eslint-config-enrise-mm/es5"]
+  "extends": ["eslint-config-mm/es5"]
 }
 ```

--- a/es5.js
+++ b/es5.js
@@ -7,6 +7,7 @@ module.exports = {
   },
   rules: {
     'array-bracket-spacing': [2, 'never'],
+    'array-callback-return': 2,
     'block-scoped-var': 2,
     'brace-style': [2, '1tbs', {
       allowSingleLine: true
@@ -45,6 +46,7 @@ module.exports = {
     'no-extra-bind': 2,
     'no-extra-parens': 2,
     'no-implied-eval': 2,
+    'no-iterator': 2,
     'no-labels': 2,
     'no-lone-blocks': 2,
     'no-loop-func': 2,

--- a/es5.js
+++ b/es5.js
@@ -1,5 +1,4 @@
 'use strict';
-// @TODO https://www.npmjs.com/package/eslint-plugin-lodash
 module.exports = {
   extends: ['eslint:recommended'],
   env: {

--- a/es5.js
+++ b/es5.js
@@ -1,6 +1,7 @@
 'use strict';
+// @TODO https://www.npmjs.com/package/eslint-plugin-lodash
 module.exports = {
-  extends: 'eslint:recommended',
+  extends: ['eslint:recommended'],
   env: {
     node: true
   },

--- a/es6.js
+++ b/es6.js
@@ -1,0 +1,30 @@
+'use strict';
+module.exports = {
+  extends: ['eslint-config-mm/es5'],
+  parserOptions: {
+    ecmaVersion: 6
+    // Can't use ES6 imports yet in node: https://github.com/nodejs/help/issues/53#issuecomment-165763446
+    // sourceType: 'module'
+  },
+  env: {
+    node: true,
+    es6: true
+  },
+  rules: {
+    'array-callback-return': 1,
+    'arrow-parens': [1, 'always'],
+    'arrow-body-style': [1, 'always'],
+    'arrow-spacing': 1,
+    'no-const-assign': 1,
+    'no-iterator': 1,
+    'no-var': 1,
+    'object-shorthand': 1,
+    'prefer-arrow-callback': 1,
+    'prefer-const': 1,
+    //  Can't use rest params yet: https://github.com/nodejs/node/issues/5411
+    // 'prefer-rest-params': 1,
+    'prefer-spread': 1,
+    'prefer-template': 1,
+    'template-curly-spacing': [1, 'never']
+  }
+}

--- a/es6.js
+++ b/es6.js
@@ -7,7 +7,6 @@ module.exports = {
     // sourceType: 'module'
   },
   env: {
-    node: true,
     es6: true
   },
   rules: {

--- a/es6.js
+++ b/es6.js
@@ -3,25 +3,26 @@ module.exports = {
   extends: ['eslint-config-mm/es5'],
   parserOptions: {
     ecmaVersion: 6
-    // Can't use ES6 imports yet in node: https://github.com/nodejs/help/issues/53#issuecomment-165763446
-    // sourceType: 'module'
+  // Can't use ES6 imports yet in node: https://github.com/nodejs/help/issues/53#issuecomment-165763446
+  // sourceType: 'module'
   },
   env: {
     es6: true
   },
   rules: {
-    'arrow-parens': [1, 'always'],
-    'arrow-body-style': [1, 'always'],
-    'arrow-spacing': 1,
-    'no-const-assign': 1,
+    'arrow-parens': [2, 'always'],
+    'arrow-body-style': [2, 'always'],
+    'arrow-spacing': 2,
+    'no-const-assign': 2,
+    'no-confusing-arrow': 2,
     'no-var': 1,
     'object-shorthand': 1,
     'prefer-arrow-callback': 1,
-    'prefer-const': 1,
+    'prefer-const': 2,
     //  Can't use rest params yet: https://github.com/nodejs/node/issues/5411
     // 'prefer-rest-params': 1,
     'prefer-spread': 1,
     'prefer-template': 1,
-    'template-curly-spacing': [1, 'never']
+    'template-curly-spacing': [2, 'never']
   }
-}
+};

--- a/es6.js
+++ b/es6.js
@@ -10,12 +10,10 @@ module.exports = {
     es6: true
   },
   rules: {
-    'array-callback-return': 1,
     'arrow-parens': [1, 'always'],
     'arrow-body-style': [1, 'always'],
     'arrow-spacing': 1,
     'no-const-assign': 1,
-    'no-iterator': 1,
     'no-var': 1,
     'object-shorthand': 1,
     'prefer-arrow-callback': 1,

--- a/es6.js
+++ b/es6.js
@@ -16,7 +16,7 @@ module.exports = {
     'no-const-assign': 2,
     'no-confusing-arrow': 2,
     'no-var': 1,
-    'object-shorthand': 1,
+    'object-shorthand': [1, 'never'],
     'prefer-arrow-callback': 1,
     'prefer-const': 2,
     //  Can't use rest params yet: https://github.com/nodejs/node/issues/5411

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = require('./es6');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "eslint-config-mm",
+  "version": "1.0.0",
+  "description": "Eslint rules for Matchminds projects @ Enrise",
+  "main": "index.js",
+  "scripts": {
+    "test": "eslint ."
+  },
+  "author": "Team Matchminds @ Enrise",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:Enrise/eslint-config-mm.git"
+  },
+  "devDependencies": {
+    "eslint": "^2.4.0"
+  }
+}


### PR DESCRIPTION
### Ticket

Link to ticket: https://enrise.atlassian.net/browse/MM-340
### What has been done
- Added current ES5-based ruleset
- Extended that with a proposed ES6-based ruleset
- Added instructions on how to include in a project
### How to test
- see README.md
### Todo
- [X] Reach consensus on ES6 setup
- [X] <del>Include linting rules from eslint-plugin-lodash</del> [MM-345](https://enrise.atlassian.net/browse/MM-345)
### Notes

Will be published to npm after merge (for now use `npm link` for local testing)
