### PR TITLE
Disable prefer-spread in eslint.

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -21,7 +21,7 @@ module.exports = {
     'prefer-const': 2,
     //  Can't use rest params yet: https://github.com/nodejs/node/issues/5411
     // 'prefer-rest-params': 1,
-    'prefer-spread': 2,
+    // 'prefer-spread': 2,
     'prefer-template': 2,
     'template-curly-spacing': [2, 'never']
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mm",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Eslint rules for Matchminds projects @ Enrise",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Context

No ticket
### What has been done
- Disabled the prefer-spread operator as it's not supported in argon.
