### PR TITLE
Prefer shorter notations

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,4 @@
+{
+  "root": true,
+  "extends": "./index.js"
+}

--- a/es6.js
+++ b/es6.js
@@ -1,6 +1,6 @@
 'use strict';
 module.exports = {
-  extends: ['eslint-config-mm/es5'],
+  extends: ['./es5.js'],
   parserOptions: {
     ecmaVersion: 6
   // Can't use ES6 imports yet in node: https://github.com/nodejs/help/issues/53#issuecomment-165763446
@@ -10,13 +10,13 @@ module.exports = {
     es6: true
   },
   rules: {
-    'arrow-parens': [2, 'always'],
-    'arrow-body-style': [2, 'always'],
+    'arrow-parens': [1, 'as-needed'],
+    'arrow-body-style': [1, 'as-needed'],
     'arrow-spacing': 2,
     'no-const-assign': 2,
     'no-confusing-arrow': 2,
     'no-var': 2,
-    'object-shorthand': [2, 'never'],
+    'object-shorthand': [1, 'always'],
     'prefer-arrow-callback': 2,
     'prefer-const': 2,
     //  Can't use rest params yet: https://github.com/nodejs/node/issues/5411

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mm",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Eslint rules for Matchminds projects @ Enrise",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,7 @@
     "type": "git",
     "url": "git@github.com:Enrise/eslint-config-mm.git"
   },
-  "devDependencies": {
-    "eslint": "^2.4.0"
+  "dependencies": {
+    "eslint": "^3.19.0"
   }
 }


### PR DESCRIPTION
### What has been done
- Prefer shorter notations for anonymous functions
  
  ```js
  (x) => { return x; }
  // becomes
  x => x
  ```

- Prefer shorter notations for object properties

  ```js
  const x = 'hi';
  const obj = {x: x};
  // becomes
  const obj = {x};
  ```

- Added `eslint` as a dependency to maintain alignment with ruleset

### How to test

```sh
npm link
cd $YOUR_PROJECT
npm link eslint-config-mm
# See warnings
eslint .
# Fix most issues
eslint --fix .
```

### Notes
- These warnings are transitional and should be switched back to errors after most refactoring efforts are complete