### PR TITLE
Update Node.js engine requirement and ESLint to v8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-sudo: false
-language: node_js
-node_js: "4.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mm",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Eslint rules for Matchminds projects @ Enrise",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,10 @@
     "type": "git",
     "url": "git@github.com:Enrise/eslint-config-mm.git"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
-    "eslint": "^3.19.0"
+    "eslint": "^8.57.1"
   }
 }


### PR DESCRIPTION
## Summary

- Bump version to 2.0.0 (major release)
- Require Node.js >=20
- Update ESLint from ^3.19.0 to ^8.57.1
- Remove unused .travis.yml