### PR TITLE
chore: add es2025 config and make it the default

### DIFF
--- a/es2025.js
+++ b/es2025.js
@@ -1,0 +1,7 @@
+'use strict';
+module.exports = {
+  extends: ['./es6.js'],
+  parserOptions: {
+    ecmaVersion: 2025
+  }
+};

--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 'use strict';
-module.exports = require('./es6');
+module.exports = require('./es2025');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mm",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Eslint rules for Matchminds projects @ Enrise",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Add `es2025.js` that extends `es6.js` and sets `ecmaVersion: 2025`, enabling async/await and all modern syntax supported by Node >=20
- Update `index.js` to export the new `es2025` config (default for consumers of `eslint-config-mm`)
- Keep `es6.js` unchanged — available for projects that still need strict ES6 parsing
- Bump version to `2.1.0`